### PR TITLE
Cutoffs for unobserved nodes

### DIFF
--- a/src/constant.rs
+++ b/src/constant.rs
@@ -1,6 +1,5 @@
-use crate::{Anchor, AnchorInner, Engine, OutputContext, UpdateContext};
+use crate::{Anchor, AnchorHandle, AnchorInner, Engine, OutputContext, Poll, UpdateContext};
 use std::panic::Location;
-use std::task::Poll;
 
 pub struct Constant<T> {
     val: T,
@@ -21,11 +20,15 @@ impl<T: 'static> Constant<T> {
 
 impl<T: 'static, E: Engine> AnchorInner<E> for Constant<T> {
     type Output = T;
-    fn dirty(&mut self, _child: &E::AnchorData) {
+    fn dirty(&mut self, _child: &<E::AnchorHandle as AnchorHandle>::Token) {
         panic!("Constant never has any inputs; dirty should not have been called.")
     }
-    fn poll_updated<G: UpdateContext<Engine = E>>(&mut self, _ctx: &mut G) -> Poll<bool> {
-        let res = Poll::Ready(self.first_poll);
+    fn poll_updated<G: UpdateContext<Engine = E>>(&mut self, _ctx: &mut G) -> Poll {
+        let res = if self.first_poll {
+            Poll::Updated
+        } else {
+            Poll::Unchanged
+        };
         self.first_poll = false;
         res
     }

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -62,6 +62,7 @@ where
             anchors: (self.clone(),),
             f,
             output: None,
+            output_stale: true,
             location: Location::caller(),
         })
     }
@@ -78,6 +79,7 @@ where
             f,
             f_anchor: None,
             location: Location::caller(),
+            lhs_stale: true,
         })
     }
 
@@ -148,6 +150,7 @@ macro_rules! impl_tuple_ext {
                     anchors: ($(self.$num.clone(),)+),
                     f,
                     output: None,
+                    output_stale: true,
                     location: Location::caller(),
                 })
             }
@@ -164,6 +167,7 @@ macro_rules! impl_tuple_ext {
                     f,
                     f_anchor: None,
                     location: Location::caller(),
+                    lhs_stale: true,
                 })
             }
         }

--- a/src/ext/refmap.rs
+++ b/src/ext/refmap.rs
@@ -1,6 +1,5 @@
-use crate::{Anchor, AnchorInner, Engine, OutputContext, UpdateContext};
+use crate::{Anchor, AnchorInner, Engine, OutputContext, Poll, UpdateContext};
 use std::panic::Location;
-use std::task::Poll;
 
 pub struct RefMap<A, F> {
     pub(super) f: F,
@@ -15,24 +14,12 @@ where
 {
     type Output = Out;
 
-    fn dirty(&mut self, _edge: &E::AnchorData) {
+    fn dirty(&mut self, _edge: &<E::AnchorHandle as crate::AnchorHandle>::Token) {
         // noop
     }
-    fn poll_updated<G: UpdateContext<Engine = E>>(&mut self, ctx: &mut G) -> Poll<bool> {
-        let mut found_pending = false;
-
-        if ctx.request(&self.anchors.0, true).is_pending() {
-            found_pending = true;
-        }
-
-        if found_pending {
-            return Poll::Pending;
-        }
-
-        // TODO fix always marking as dirty
-        Poll::Ready(true)
+    fn poll_updated<G: UpdateContext<Engine = E>>(&mut self, ctx: &mut G) -> Poll {
+        ctx.request(&self.anchors.0, true)
     }
-
     fn output<'slf, 'out, G: OutputContext<'out, Engine = E>>(
         &'slf self,
         ctx: &mut G,

--- a/src/fakeheap.rs
+++ b/src/fakeheap.rs
@@ -1,12 +1,9 @@
-use slotmap::{Key, SecondaryMap};
-
-pub struct FakeHeap<T: Key> {
+pub struct FakeHeap<T> {
     min_height: usize,
     lists: Vec<Vec<T>>,
-    contained_keys: SecondaryMap<T, usize>,
 }
 
-impl<T: Key> FakeHeap<T> {
+impl<T> FakeHeap<T> {
     pub fn new(max_height: usize) -> Self {
         let mut lists = Vec::with_capacity(max_height);
         for _ in 0..max_height {
@@ -15,7 +12,6 @@ impl<T: Key> FakeHeap<T> {
         Self {
             lists,
             min_height: max_height,
-            contained_keys: SecondaryMap::new(),
         }
     }
 
@@ -27,11 +23,6 @@ impl<T: Key> FakeHeap<T> {
                 self.lists.len() - 1
             );
         }
-        if let Some(count) = self.contained_keys.get_mut(item.clone()) {
-            *count += 1;
-        } else {
-            self.contained_keys.insert(item.clone(), 1);
-        }
         self.lists[height].push(item);
         self.min_height = self.min_height.min(height);
     }
@@ -39,8 +30,6 @@ impl<T: Key> FakeHeap<T> {
     pub fn pop_min(&mut self) -> Option<(usize, T)> {
         while self.min_height < self.lists.len() {
             if let Some(v) = self.lists[self.min_height].pop() {
-                let old_count = self.contained_keys.get_mut(v.clone()).unwrap();
-                *old_count = *old_count - 1;
                 return Some((self.min_height, v));
             } else {
                 self.min_height += 1;
@@ -48,80 +37,33 @@ impl<T: Key> FakeHeap<T> {
         }
         None
     }
-
-    pub fn contains(&self, item: T) -> bool {
-        if let Some(count) = self.contained_keys.get(item) {
-            *count > 0
-        } else {
-            false
-        }
-    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use slotmap::{DefaultKey, SlotMap};
 
     #[test]
-    fn test_insert_pop_and_contains() {
-        let (a, b, c, d, e) = {
-            let mut map = SlotMap::new();
-            (
-                map.insert(()),
-                map.insert(()),
-                map.insert(()),
-                map.insert(()),
-                map.insert(()),
-            )
-        };
-        let mut heap: FakeHeap<DefaultKey> = FakeHeap::new(10);
+    fn test_insert_pop() {
+        let mut heap: FakeHeap<i32> = FakeHeap::new(10);
 
-        assert_eq!(false, heap.contains(a));
-        assert_eq!(false, heap.contains(b));
-        assert_eq!(false, heap.contains(c));
-        assert_eq!(false, heap.contains(d));
-        assert_eq!(false, heap.contains(e));
+        heap.insert(0, 1);
+        heap.insert(0, 1);
+        heap.insert(0, 1);
+        heap.insert(5, 2);
+        heap.insert(3, 3);
+        heap.insert(4, 4);
 
-        heap.insert(0, a);
-        heap.insert(0, a);
-        heap.insert(0, a);
-        heap.insert(5, b);
-        heap.insert(3, c);
-        heap.insert(4, d);
+        assert_eq!(Some(1), heap.pop_min().map(|(_, v)| v));
+        assert_eq!(Some(1), heap.pop_min().map(|(_, v)| v));
+        assert_eq!(Some(1), heap.pop_min().map(|(_, v)| v));
+        assert_eq!(Some(3), heap.pop_min().map(|(_, v)| v));
+        assert_eq!(Some(4), heap.pop_min().map(|(_, v)| v));
 
-        assert_eq!(true, heap.contains(a));
-        assert_eq!(true, heap.contains(b));
-        assert_eq!(true, heap.contains(c));
-        assert_eq!(true, heap.contains(d));
-        assert_eq!(false, heap.contains(e));
+        heap.insert(1, 5);
 
-        assert_eq!(Some(a), heap.pop_min().map(|(_, v)| v));
-        assert_eq!(true, heap.contains(a));
-        assert_eq!(Some(a), heap.pop_min().map(|(_, v)| v));
-        assert_eq!(true, heap.contains(a));
-        assert_eq!(Some(a), heap.pop_min().map(|(_, v)| v));
-        assert_eq!(false, heap.contains(a));
-        assert_eq!(Some(c), heap.pop_min().map(|(_, v)| v));
-        assert_eq!(Some(d), heap.pop_min().map(|(_, v)| v));
-
-        assert_eq!(false, heap.contains(a));
-        assert_eq!(true, heap.contains(b));
-        assert_eq!(false, heap.contains(c));
-        assert_eq!(false, heap.contains(d));
-        assert_eq!(false, heap.contains(e));
-
-        heap.insert(1, e);
-        assert_eq!(true, heap.contains(e));
-
-        assert_eq!(Some(e), heap.pop_min().map(|(_, v)| v));
-        assert_eq!(Some(b), heap.pop_min().map(|(_, v)| v));
-
-        assert_eq!(false, heap.contains(a));
-        assert_eq!(false, heap.contains(b));
-        assert_eq!(false, heap.contains(c));
-        assert_eq!(false, heap.contains(d));
-        assert_eq!(false, heap.contains(e));
+        assert_eq!(Some(5), heap.pop_min().map(|(_, v)| v));
+        assert_eq!(Some(2), heap.pop_min().map(|(_, v)| v));
 
         assert_eq!(None, heap.pop_min().map(|(_, v)| v));
     }
@@ -129,7 +71,7 @@ mod test {
     #[test]
     #[should_panic]
     fn test_insert_above_max_height() {
-        let mut heap: FakeHeap<DefaultKey> = FakeHeap::new(10);
-        heap.insert(10, DefaultKey::null());
+        let mut heap: FakeHeap<i32> = FakeHeap::new(10);
+        heap.insert(10, 1);
     }
 }

--- a/src/nodequeue.rs
+++ b/src/nodequeue.rs
@@ -1,0 +1,50 @@
+use crate::fakeheap::FakeHeap;
+use slotmap::{Key, SecondaryMap};
+
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub enum NodeState {
+    NeedsRecalc,
+    PendingRecalc,
+    Ready,
+}
+
+pub struct NodeQueue<T: Key> {
+    heap: FakeHeap<T>,
+    states: SecondaryMap<T, NodeState>,
+}
+
+impl<T: Key> NodeQueue<T> {
+    pub fn new(max_height: usize) -> Self {
+        Self {
+            heap: FakeHeap::new(max_height),
+            states: SecondaryMap::new(),
+        }
+    }
+
+    pub fn queue_recalc(&mut self, height: usize, node: T) {
+        if self.states.get(node.clone()) == Some(&NodeState::PendingRecalc) {
+            panic!("node already queued for recalc");
+        }
+        self.states.insert(node.clone(), NodeState::PendingRecalc);
+        self.heap.insert(height, node);
+    }
+
+    pub fn needs_recalc(&mut self, node: T) {
+        self.states.insert(node, NodeState::NeedsRecalc);
+    }
+
+    pub fn pop_next(&mut self) -> Option<(usize, T)> {
+        let next = self.heap.pop_min();
+        if let Some((_, next)) = next.clone() {
+            self.states.insert(next, NodeState::Ready);
+        }
+        next
+    }
+
+    pub fn state(&self, node: T) -> NodeState {
+        self.states
+            .get(node)
+            .cloned()
+            .unwrap_or(NodeState::NeedsRecalc)
+    }
+}

--- a/src/var.rs
+++ b/src/var.rs
@@ -1,7 +1,8 @@
-use super::{Anchor, AnchorInner, DirtyHandle, Engine, OutputContext, UpdateContext};
+use super::{
+    Anchor, AnchorHandle, AnchorInner, DirtyHandle, Engine, OutputContext, Poll, UpdateContext,
+};
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::task::Poll;
 
 pub struct Var<T, H> {
     inner: Rc<RefCell<VarInner<T, H>>>,
@@ -51,11 +52,11 @@ impl<T: 'static, H: DirtyHandle> VarSetter<T, H> {
 
 impl<E: Engine, T: 'static> AnchorInner<E> for Var<T, E::DirtyHandle> {
     type Output = T;
-    fn dirty(&mut self, _edge: &E::AnchorData) {
+    fn dirty(&mut self, _edge: &<E::AnchorHandle as AnchorHandle>::Token) {
         panic!("somehow an input was dirtied on var; it never has any inputs to dirty")
     }
 
-    fn poll_updated<G: UpdateContext<Engine = E>>(&mut self, ctx: &mut G) -> Poll<bool> {
+    fn poll_updated<G: UpdateContext<Engine = E>>(&mut self, ctx: &mut G) -> Poll {
         let mut inner = self.inner.borrow_mut();
         let first_update = inner.dirty_handle.is_none();
         if first_update {
@@ -63,10 +64,11 @@ impl<E: Engine, T: 'static> AnchorInner<E> for Var<T, E::DirtyHandle> {
         }
         if let Some(new_val) = inner.val.take() {
             self.my_val = new_val;
-            Poll::Ready(true)
+            Poll::Updated
+        } else if first_update {
+            Poll::Updated
         } else {
-            // always true if this is the first update
-            Poll::Ready(first_update)
+            Poll::Unchanged
         }
     }
 


### PR DESCRIPTION
Fixes #2 
Fixes #5 
Fixes #12 

- Each AnchorHandle now has a token, a non reference-counted unique identifier. To actually request a node you still need the actual AnchorHandle, so that you can't request a node that has been garbage collected away.
- UpdateContext now has unrequest; this cancels notifications for a previously requested dependency that is no longer needed. Then uses this to unfollow old nodes.
- Dirty bits now stored alongside heap of recalculations, instead of the graph.
- Edges now only set to dirty if the value actually changes. Otherwise, kept as-is, but the nodes themselves are marked as dirty.
- Nodes calling `request` are now actually informed if the value has changed since their last request, and many will skip calculations if nothing has changed.