### PR TITLE
Add benchmarks, substantial performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+*.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,10 @@ repository = "https://github.com/lord/anchors"
 [dependencies]
 slotmap = { version = "0.4.0", features = ["unstable"] }
 petgraph = "0.5.1"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "benchmarks"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ license = "MIT"
 documentation = "https://docs.rs/anchors"
 repository = "https://github.com/lord/anchors"
 
+[lib]
+bench = false
+
 [dependencies]
 slotmap = { version = "0.4.0", features = ["unstable"] }
 petgraph = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,12 @@ criterion = "0.3"
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[profile.release]
+debug = true
+
+[[bin]]
+name = "linear_recalc"
+test = false
+bench = false
+

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -3,7 +3,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, Benchmark
 
 fn stabilize_linear_nodes(c: &mut Criterion) {
     for input in &[10, 100, 1000] {
-        c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes", *input), input, |b, i| {
+        c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes_unobserved", *input), input, |b, i| {
             let mut engine = Engine::new_with_max_height(1003);
             let (first_num, set_first_num) = Var::new(0u64);
             let mut node = first_num;
@@ -23,7 +23,7 @@ fn stabilize_linear_nodes(c: &mut Criterion) {
 
 fn stabilize_observed_linear_nodes(c: &mut Criterion) {
     for input in &[10, 100, 1000] {
-        c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes", *input), input, |b, i| {
+        c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes_observed", *input), input, |b, i| {
             let mut engine = Engine::new_with_max_height(1003);
             let (first_num, set_first_num) = Var::new(0u64);
             let mut node = first_num;
@@ -45,6 +45,6 @@ fn stabilize_observed_linear_nodes(c: &mut Criterion) {
 criterion_group!{
     name = benches;
     config = Criterion::default();
-    targets = stabilize_linear_nodes
+    targets = stabilize_linear_nodes, stabilize_observed_linear_nodes
 }
 criterion_main!(benches);

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -21,9 +21,30 @@ fn stabilize_linear_nodes(c: &mut Criterion) {
     }
 }
 
+fn stabilize_observed_linear_nodes(c: &mut Criterion) {
+    for input in &[10, 100, 1000] {
+        c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes", *input), input, |b, i| {
+            let mut engine = Engine::new_with_max_height(1003);
+            let (first_num, set_first_num) = Var::new(0u64);
+            let mut node = first_num;
+            for _ in 0..*i {
+                node = node.map(|val| val + black_box(1));
+            }
+            engine.mark_observed(&node);
+            assert_eq!(engine.get(&node), *i);
+            let mut update_number = 0;
+            b.iter(|| {
+                update_number += 1;
+                set_first_num.set(update_number);
+                assert_eq!(engine.get(&node), update_number+*i);
+            });
+        });
+    }
+}
+
 criterion_group!{
     name = benches;
-    config = Criterion::default().measurement_time(std::time::Duration::from_secs(15));
+    config = Criterion::default();
     targets = stabilize_linear_nodes
 }
 criterion_main!(benches);

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,29 @@
+use anchors::{singlethread::Engine, AnchorExt, Var};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+
+fn stabilize_linear_nodes(c: &mut Criterion) {
+    for input in &[10, 100, 1000] {
+        c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes", *input), input, |b, i| {
+            let mut engine = Engine::new_with_max_height(1003);
+            let (first_num, set_first_num) = Var::new(0u64);
+            let mut node = first_num;
+            for _ in 0..*i {
+                node = node.map(|val| val + black_box(1));
+            }
+            assert_eq!(engine.get(&node), *i);
+            let mut update_number = 0;
+            b.iter(|| {
+                update_number += 1;
+                set_first_num.set(update_number);
+                assert_eq!(engine.get(&node), update_number+*i);
+            });
+        });
+    }
+}
+
+criterion_group!{
+    name = benches;
+    config = Criterion::default().measurement_time(std::time::Duration::from_secs(15));
+    targets = stabilize_linear_nodes
+}
+criterion_main!(benches);

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,27 +1,38 @@
 use anchors::{singlethread::Engine, AnchorExt, Var};
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
 fn stabilize_linear_nodes(c: &mut Criterion) {
     for node_count in &[10, 100, 1000] {
         for observed in &[true, false] {
-            c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes", format!("{}/{}", node_count, if *observed {"observed"} else {"unobserved"})), &(*node_count, *observed), |b, (node_count, observed)| {
-                let mut engine = Engine::new_with_max_height(1003);
-                let (first_num, set_first_num) = Var::new(0u64);
-                let mut node = first_num;
-                for _ in 0..*node_count {
-                    node = node.map(|val| val + black_box(1));
-                }
-                if *observed {
-                    engine.mark_observed(&node);
-                }
-                assert_eq!(engine.get(&node), *node_count);
-                let mut update_number = 0;
-                b.iter(|| {
-                    update_number += 1;
-                    set_first_num.set(update_number);
-                    assert_eq!(engine.get(&node), update_number+*node_count);
-                });
-            });
+            c.bench_with_input(
+                BenchmarkId::new(
+                    "stabilize_linear_nodes",
+                    format!(
+                        "{}/{}",
+                        node_count,
+                        if *observed { "observed" } else { "unobserved" }
+                    ),
+                ),
+                &(*node_count, *observed),
+                |b, (node_count, observed)| {
+                    let mut engine = Engine::new_with_max_height(1003);
+                    let (first_num, set_first_num) = Var::new(0u64);
+                    let mut node = first_num;
+                    for _ in 0..*node_count {
+                        node = node.map(|val| val + black_box(1));
+                    }
+                    if *observed {
+                        engine.mark_observed(&node);
+                    }
+                    assert_eq!(engine.get(&node), *node_count);
+                    let mut update_number = 0;
+                    b.iter(|| {
+                        update_number += 1;
+                        set_first_num.set(update_number);
+                        assert_eq!(engine.get(&node), update_number + *node_count);
+                    });
+                },
+            );
         }
     }
 }
@@ -29,24 +40,35 @@ fn stabilize_linear_nodes(c: &mut Criterion) {
 fn stabilize_linear_nodes_smallheight(c: &mut Criterion) {
     for node_count in &[10, 100] {
         for observed in &[true, false] {
-            c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes_smallheight", format!("{}/{}", node_count, if *observed {"observed"} else {"unobserved"})), &(*node_count, *observed), |b, (node_count, observed)| {
-                let mut engine = Engine::new_with_max_height(128);
-                let (first_num, set_first_num) = Var::new(0u64);
-                let mut node = first_num;
-                for _ in 0..*node_count {
-                    node = node.map(|val| val + black_box(1));
-                }
-                if *observed {
-                    engine.mark_observed(&node);
-                }
-                assert_eq!(engine.get(&node), *node_count);
-                let mut update_number = 0;
-                b.iter(|| {
-                    update_number += 1;
-                    set_first_num.set(update_number);
-                    assert_eq!(engine.get(&node), update_number+*node_count);
-                });
-            });
+            c.bench_with_input(
+                BenchmarkId::new(
+                    "stabilize_linear_nodes_smallheight",
+                    format!(
+                        "{}/{}",
+                        node_count,
+                        if *observed { "observed" } else { "unobserved" }
+                    ),
+                ),
+                &(*node_count, *observed),
+                |b, (node_count, observed)| {
+                    let mut engine = Engine::new_with_max_height(128);
+                    let (first_num, set_first_num) = Var::new(0u64);
+                    let mut node = first_num;
+                    for _ in 0..*node_count {
+                        node = node.map(|val| val + black_box(1));
+                    }
+                    if *observed {
+                        engine.mark_observed(&node);
+                    }
+                    assert_eq!(engine.get(&node), *node_count);
+                    let mut update_number = 0;
+                    b.iter(|| {
+                        update_number += 1;
+                        set_first_num.set(update_number);
+                        assert_eq!(engine.get(&node), update_number + *node_count);
+                    });
+                },
+            );
         }
     }
 }
@@ -54,41 +76,52 @@ fn stabilize_linear_nodes_smallheight(c: &mut Criterion) {
 fn stabilize_linear_nodes_cutoff(c: &mut Criterion) {
     for node_count in &[10, 100, 1000] {
         for observed in &[true, false] {
-            c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes_cutoff", format!("{}/{}", node_count, if *observed {"observed"} else {"unobserved"})), &(*node_count, *observed), |b, (node_count, observed)| {
-                let mut engine = Engine::new_with_max_height(1003);
-                let (first_num, set_first_num) = Var::new(0u64);
-                let node = first_num;
-                let node = node.map(|val| black_box(val) - black_box(val) + 1);
-                let mut node = {
-                    let mut old_val = None;
-                    node.cutoff(move |val| {
-                        if Some(*val) != old_val {
-                            old_val = Some(*val);
-                            true
-                        } else {
-                            false
-                        }
-                    })
-                };
-                for i in 0..*node_count {
-                    node = node.map(move |val| black_box(val) - black_box(val) + black_box(i));
-                }
-                if *observed {
-                    engine.mark_observed(&node);
-                }
-                assert_eq!(engine.get(&node), *node_count-1);
-                let mut update_number = 0;
-                b.iter(|| {
-                    update_number += 1;
-                    set_first_num.set(update_number);
-                    assert_eq!(engine.get(&node), *node_count-1);
-                });
-            });
+            c.bench_with_input(
+                BenchmarkId::new(
+                    "stabilize_linear_nodes_cutoff",
+                    format!(
+                        "{}/{}",
+                        node_count,
+                        if *observed { "observed" } else { "unobserved" }
+                    ),
+                ),
+                &(*node_count, *observed),
+                |b, (node_count, observed)| {
+                    let mut engine = Engine::new_with_max_height(1003);
+                    let (first_num, set_first_num) = Var::new(0u64);
+                    let node = first_num;
+                    let node = node.map(|val| black_box(val) - black_box(val) + 1);
+                    let mut node = {
+                        let mut old_val = None;
+                        node.cutoff(move |val| {
+                            if Some(*val) != old_val {
+                                old_val = Some(*val);
+                                true
+                            } else {
+                                false
+                            }
+                        })
+                    };
+                    for i in 0..*node_count {
+                        node = node.map(move |val| black_box(val) - black_box(val) + black_box(i));
+                    }
+                    if *observed {
+                        engine.mark_observed(&node);
+                    }
+                    assert_eq!(engine.get(&node), *node_count - 1);
+                    let mut update_number = 0;
+                    b.iter(|| {
+                        update_number += 1;
+                        set_first_num.set(update_number);
+                        assert_eq!(engine.get(&node), *node_count - 1);
+                    });
+                },
+            );
         }
     }
 }
 
-criterion_group!{
+criterion_group! {
     name = benches;
     config = Criterion::default();
     targets = stabilize_linear_nodes_cutoff, stabilize_linear_nodes_smallheight, stabilize_linear_nodes

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -2,49 +2,95 @@ use anchors::{singlethread::Engine, AnchorExt, Var};
 use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
 
 fn stabilize_linear_nodes(c: &mut Criterion) {
-    for input in &[10, 100, 1000] {
-        c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes_unobserved", *input), input, |b, i| {
-            let mut engine = Engine::new_with_max_height(1003);
-            let (first_num, set_first_num) = Var::new(0u64);
-            let mut node = first_num;
-            for _ in 0..*i {
-                node = node.map(|val| val + black_box(1));
-            }
-            assert_eq!(engine.get(&node), *i);
-            let mut update_number = 0;
-            b.iter(|| {
-                update_number += 1;
-                set_first_num.set(update_number);
-                assert_eq!(engine.get(&node), update_number+*i);
+    for node_count in &[10, 100, 1000] {
+        for observed in &[true, false] {
+            c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes", format!("{}/{}", node_count, if *observed {"observed"} else {"unobserved"})), &(*node_count, *observed), |b, (node_count, observed)| {
+                let mut engine = Engine::new_with_max_height(1003);
+                let (first_num, set_first_num) = Var::new(0u64);
+                let mut node = first_num;
+                for _ in 0..*node_count {
+                    node = node.map(|val| val + black_box(1));
+                }
+                if *observed {
+                    engine.mark_observed(&node);
+                }
+                assert_eq!(engine.get(&node), *node_count);
+                let mut update_number = 0;
+                b.iter(|| {
+                    update_number += 1;
+                    set_first_num.set(update_number);
+                    assert_eq!(engine.get(&node), update_number+*node_count);
+                });
             });
-        });
+        }
     }
 }
 
-fn stabilize_observed_linear_nodes(c: &mut Criterion) {
-    for input in &[10, 100, 1000] {
-        c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes_observed", *input), input, |b, i| {
-            let mut engine = Engine::new_with_max_height(1003);
-            let (first_num, set_first_num) = Var::new(0u64);
-            let mut node = first_num;
-            for _ in 0..*i {
-                node = node.map(|val| val + black_box(1));
-            }
-            engine.mark_observed(&node);
-            assert_eq!(engine.get(&node), *i);
-            let mut update_number = 0;
-            b.iter(|| {
-                update_number += 1;
-                set_first_num.set(update_number);
-                assert_eq!(engine.get(&node), update_number+*i);
+fn stabilize_linear_nodes_smallheight(c: &mut Criterion) {
+    for node_count in &[10, 100] {
+        for observed in &[true, false] {
+            c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes_smallheight", format!("{}/{}", node_count, if *observed {"observed"} else {"unobserved"})), &(*node_count, *observed), |b, (node_count, observed)| {
+                let mut engine = Engine::new_with_max_height(128);
+                let (first_num, set_first_num) = Var::new(0u64);
+                let mut node = first_num;
+                for _ in 0..*node_count {
+                    node = node.map(|val| val + black_box(1));
+                }
+                if *observed {
+                    engine.mark_observed(&node);
+                }
+                assert_eq!(engine.get(&node), *node_count);
+                let mut update_number = 0;
+                b.iter(|| {
+                    update_number += 1;
+                    set_first_num.set(update_number);
+                    assert_eq!(engine.get(&node), update_number+*node_count);
+                });
             });
-        });
+        }
+    }
+}
+
+fn stabilize_linear_nodes_cutoff(c: &mut Criterion) {
+    for node_count in &[10, 100, 1000] {
+        for observed in &[true, false] {
+            c.bench_with_input(BenchmarkId::new("stabilize_linear_nodes_cutoff", format!("{}/{}", node_count, if *observed {"observed"} else {"unobserved"})), &(*node_count, *observed), |b, (node_count, observed)| {
+                let mut engine = Engine::new_with_max_height(1003);
+                let (first_num, set_first_num) = Var::new(0u64);
+                let node = first_num;
+                let node = node.map(|val| black_box(val) - black_box(val) + 1);
+                let mut node = {
+                    let mut old_val = None;
+                    node.cutoff(move |val| {
+                        if Some(*val) != old_val {
+                            old_val = Some(*val);
+                            true
+                        } else {
+                            false
+                        }
+                    })
+                };
+                for i in 0..*node_count {
+                    node = node.map(move |val| black_box(val) - black_box(val) + black_box(i));
+                }
+                if *observed {
+                    engine.mark_observed(&node);
+                }
+                assert_eq!(engine.get(&node), *node_count-1);
+                let mut update_number = 0;
+                b.iter(|| {
+                    update_number += 1;
+                    set_first_num.set(update_number);
+                    assert_eq!(engine.get(&node), *node_count-1);
+                });
+            });
+        }
     }
 }
 
 criterion_group!{
     name = benches;
     config = Criterion::default();
-    targets = stabilize_linear_nodes, stabilize_observed_linear_nodes
+    targets = stabilize_linear_nodes_cutoff, stabilize_linear_nodes_smallheight, stabilize_linear_nodes
 }
 criterion_main!(benches);

--- a/src/bin/linear_recalc.rs
+++ b/src/bin/linear_recalc.rs
@@ -10,9 +10,9 @@ fn main() {
     assert_eq!(engine.get(&node), 1000);
     let mut update_number = 0;
 
-    for _ in  0..50000 {
+    for _ in 0..50000 {
         update_number += 1;
         set_first_num.set(update_number);
-        assert_eq!(engine.get(&node), update_number+1000);
+        assert_eq!(engine.get(&node), update_number + 1000);
     }
 }

--- a/src/bin/linear_recalc.rs
+++ b/src/bin/linear_recalc.rs
@@ -10,7 +10,7 @@ fn main() {
     assert_eq!(engine.get(&node), 1000);
     let mut update_number = 0;
 
-    for _ in  0..100 {
+    for _ in  0..1000 {
         update_number += 1;
         set_first_num.set(update_number);
         assert_eq!(engine.get(&node), update_number+1000);

--- a/src/bin/linear_recalc.rs
+++ b/src/bin/linear_recalc.rs
@@ -7,6 +7,7 @@ fn main() {
     for _ in 0..1000 {
         node = node.map(|val| val + 1);
     }
+    engine.mark_observed(&node);
     assert_eq!(engine.get(&node), 1000);
     let mut update_number = 0;
 

--- a/src/bin/linear_recalc.rs
+++ b/src/bin/linear_recalc.rs
@@ -7,11 +7,10 @@ fn main() {
     for _ in 0..1000 {
         node = node.map(|val| val + 1);
     }
-    engine.mark_observed(&node);
     assert_eq!(engine.get(&node), 1000);
     let mut update_number = 0;
 
-    for _ in  0..1000 {
+    for _ in  0..50000 {
         update_number += 1;
         set_first_num.set(update_number);
         assert_eq!(engine.get(&node), update_number+1000);

--- a/src/bin/linear_recalc.rs
+++ b/src/bin/linear_recalc.rs
@@ -1,0 +1,18 @@
+use anchors::{singlethread::Engine, AnchorExt, Var};
+
+fn main() {
+    let mut engine = Engine::new_with_max_height(1003);
+    let (first_num, set_first_num) = Var::new(0u64);
+    let mut node = first_num;
+    for _ in 0..1000 {
+        node = node.map(|val| val + 1);
+    }
+    assert_eq!(engine.get(&node), 1000);
+    let mut update_number = 0;
+
+    for _ in  0..100 {
+        update_number += 1;
+        set_first_num.set(update_number);
+        assert_eq!(engine.get(&node), update_number+1000);
+    }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -120,31 +120,37 @@ impl<T: Eq + Copy + Debug + Key + Ord> MetadataGraph<T> {
         self.nodes.remove(node_id);
     }
 
-    pub fn necessary_parents<'a>(&'a self, node_id: T) -> Option<impl std::iter::Iterator<Item=T> + 'a> {
+    pub fn necessary_parents<'a>(
+        &'a self,
+        node_id: T,
+    ) -> Option<impl std::iter::Iterator<Item = T> + 'a> {
         let node = match self.nodes.get(node_id) {
             Some(v) => v,
             None => return None,
         };
-        Some(node.parents.iter().filter_map(|(v, necessary)| if *necessary {
-            Some(v.clone())
-        } else {
-            None
-        }))
+        Some(
+            node.parents
+                .iter()
+                .filter_map(|(v, necessary)| if *necessary { Some(v.clone()) } else { None }),
+        )
     }
 
-    pub fn clean_parents<'a>(&'a self, node_id: T) -> Option<impl std::iter::Iterator<Item=T> + 'a> {
+    pub fn clean_parents<'a>(
+        &'a self,
+        node_id: T,
+    ) -> Option<impl std::iter::Iterator<Item = T> + 'a> {
         let node = match self.nodes.get(node_id) {
             Some(v) => v,
             None => return None,
         };
-        Some(node.parents.iter().filter_map(|(v, necessary)| if !*necessary {
-            Some(v.clone())
-        } else {
-            None
-        }))
+        Some(
+            node.parents
+                .iter()
+                .filter_map(|(v, necessary)| if !*necessary { Some(v.clone()) } else { None }),
+        )
     }
 
-    pub fn parents<'a>(&'a self, node_id: T) -> Option<impl std::iter::Iterator<Item=T> + 'a> {
+    pub fn parents<'a>(&'a self, node_id: T) -> Option<impl std::iter::Iterator<Item = T> + 'a> {
         let node = match self.nodes.get(node_id) {
             Some(v) => v,
             None => return None,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -129,12 +129,12 @@ impl<T: Eq + Copy + Debug + Key + Ord> MetadataGraph<T> {
         self.get_parents(node_id, false)
     }
 
-    pub fn parents(&self, node_id: T) -> Vec<T> {
+    pub fn parents<'a>(&'a self, node_id: T) -> Option<impl std::iter::Iterator<Item=T> + 'a> {
         let node = match self.nodes.get(node_id) {
             Some(v) => v,
-            None => return vec![],
+            None => return None,
         };
-        node.parents.iter().map(|(v, _)| v.clone()).collect()
+        Some(node.parents.iter().map(|(v, _)| v.clone()))
     }
 
     #[allow(dead_code)]

--- a/src/nodequeue.rs
+++ b/src/nodequeue.rs
@@ -30,6 +30,9 @@ impl<T: Key> NodeQueue<T> {
     }
 
     pub fn needs_recalc(&mut self, node: T) {
+        if self.states.get(node.clone()) != Some(&NodeState::Ready) {
+            panic!("node queued for recalc, someone tried to mark it as NeedsRecalc");
+        }
         self.states.insert(node, NodeState::NeedsRecalc);
     }
 

--- a/src/singlethread.rs
+++ b/src/singlethread.rs
@@ -126,7 +126,7 @@ impl Engine {
     pub fn stabilize<'a>(&'a mut self) {
         let dirty_marks = std::mem::replace(&mut *self.dirty_marks.borrow_mut(), Vec::new());
         for dirty in dirty_marks {
-            self.mark_node_dirty(dirty);
+            self.mark_dirty(dirty, false);
         }
 
         while let Some((height, this_node_num)) = self.to_recalculate.pop_next() {
@@ -187,7 +187,7 @@ impl Engine {
             }
             Poll::Updated => {
                 // make sure all parents are marked as dirty, and observed parents are recalculated
-                self.mark_parents_dirty(this_node_num, true);
+                self.mark_dirty(this_node_num, true);
                 true
             }
             Poll::Unchanged => true,
@@ -211,13 +211,57 @@ impl Engine {
         }
     }
 
-    fn mark_node_dirty(&mut self, node_id: NodeNum) {
-        if self.graph.is_necessary(node_id) || self.nodes.borrow()[node_id].observed {
-            self.mark_node_for_recalculation(node_id);
-        } else if self.to_recalculate.state(node_id) == NodeState::Ready {
-            self.to_recalculate.needs_recalc(node_id);
-            self.mark_parents_dirty(node_id, false);
+    // skip_self = true indicates output has *definitely* changed, but node has been recalculated
+    // skip_self = false indicates node has not yet been recalculated
+    fn mark_dirty(&mut self, node_id: NodeNum, skip_self: bool) {
+        let mut queue = if skip_self {
+            let res = match self.graph.parents(node_id) {
+                Some(vec) => vec.collect(),
+                None => vec![],
+            };
+            for item in &res {
+                // TODO now that we don't delete edges, this is called multiple times in some cases? maybee?? but if we only call it
+                // when the parent node was previously clean...seems like at worst we call it twice?
+                self.nodes
+                    .borrow()
+                    .get(*item)
+                    .unwrap()
+                    .anchor
+                    .borrow_mut()
+                    .dirty(&node_id);
+                // mark edges as dirty, since skip_self indicates this node's output actually
+                // changed
+                let res = self
+                    .graph
+                    .set_edge(node_id, *item, graph::EdgeState::Dirty);
+                self.panic_if_loop(res);
+            }
+            res
+        } else {
+            vec![node_id]
         };
+
+        while let Some(next) = queue.pop() {
+            if self.graph.is_necessary(next) || self.nodes.borrow()[next].observed {
+                self.mark_node_for_recalculation(next);
+            } else if self.to_recalculate.state(next) == NodeState::Ready {
+                self.to_recalculate.needs_recalc(next);
+                if let Some(parents) = self.graph.parents(next) {
+                    queue.reserve(parents.size_hint().0);
+                    for parent in parents {
+                        self.nodes
+                            .borrow()
+                            .get(parent)
+                            .unwrap()
+                            .anchor
+                            .borrow_mut()
+                            .dirty(&next);
+                        queue.push(parent);
+                    }
+                }
+            };
+
+        }
     }
 
     fn mark_node_for_recalculation(&mut self, node_id: NodeNum) {
@@ -227,27 +271,6 @@ impl Engine {
         }
     }
 
-    fn mark_parents_dirty(&mut self, node_id: NodeNum, definitely_changed: bool) {
-        for parent in self.graph.parents(node_id) {
-            // TODO now that we don't delete edges, this is called multiple times in some cases
-            self.nodes
-                .borrow()
-                .get(parent)
-                .unwrap()
-                .anchor
-                .borrow_mut()
-                .dirty(&node_id);
-
-            self.mark_node_dirty(parent);
-
-            if definitely_changed {
-                let res = self
-                    .graph
-                    .set_edge(node_id, parent, graph::EdgeState::Dirty);
-                self.panic_if_loop(res);
-            }
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/src/singlethread.rs
+++ b/src/singlethread.rs
@@ -231,9 +231,7 @@ impl Engine {
                     .dirty(&node_id);
                 // mark edges as dirty, since skip_self indicates this node's output actually
                 // changed
-                let res = self
-                    .graph
-                    .set_edge(node_id, *item, graph::EdgeState::Dirty);
+                let res = self.graph.set_edge(node_id, *item, graph::EdgeState::Dirty);
                 self.panic_if_loop(res);
             }
             res
@@ -260,7 +258,6 @@ impl Engine {
                     }
                 }
             };
-
         }
     }
 
@@ -270,7 +267,6 @@ impl Engine {
                 .queue_recalc(self.graph.height(node_id), node_id);
         }
     }
-
 }
 
 #[derive(Debug)]

--- a/src/singlethread.rs
+++ b/src/singlethread.rs
@@ -186,10 +186,6 @@ impl Engine {
                 }
             }
             Poll::Updated => {
-                println!(
-                    "node updated: {}",
-                    this_anchor.borrow().debug_info().to_string()
-                );
                 // make sure all parents are marked as dirty, and observed parents are recalculated
                 self.mark_parents_dirty(this_node_num, true);
                 true


### PR DESCRIPTION
Less recursion throughout, combined with a fix for a bug where `dirty` was repeatedly called on nodes. Stabilization now one or two orders of magnitude faster — a linear chain of `n` simple integer maps takes `~300ns*n` to stabilize after the start of the chain is updated. Probably could still improve by another 10x, esp. if want parity w Incremental.