### PR TITLE
Fix observed

### DIFF
--- a/src/bin/linear_recalc.rs
+++ b/src/bin/linear_recalc.rs
@@ -3,16 +3,25 @@ use anchors::{singlethread::Engine, AnchorExt, Var};
 fn main() {
     let mut engine = Engine::new_with_max_height(1003);
     let (first_num, set_first_num) = Var::new(0u64);
-    let mut node = first_num;
-    for _ in 0..1000 {
-        node = node.map(|val| val + 1);
+    let mut node = first_num.cutoff(|_old_val| false);
+    for _ in 0..10 {
+        node = node.map(|val| {
+            println!("recalc map");
+            val + 1
+        });
     }
-    assert_eq!(engine.get(&node), 1000);
+    engine.mark_observed(&node);
+    assert_eq!(engine.get(&node), 10);
     let mut update_number = 0;
 
-    for _ in 0..50000 {
+    for _ in 0..5 {
         update_number += 1;
+        println!("== setting ==");
+        println!("{}", engine.debug_state());
         set_first_num.set(update_number);
-        assert_eq!(engine.get(&node), update_number + 1000);
+        engine.update_dirty_marks();
+        println!("== new stabilize ==");
+        println!("{}", engine.debug_state());
+        assert_eq!(engine.get(&node), 10);
     }
 }

--- a/src/ext/map.rs
+++ b/src/ext/map.rs
@@ -23,7 +23,6 @@ macro_rules! impl_tuple_map {
         {
             type Output = Out;
             fn dirty(&mut self, _edge:  &<E::AnchorHandle as crate::AnchorHandle>::Token) {
-                println!("map dirtied");
                 self.output_stale = true;
             }
             fn poll_updated<G: UpdateContext<Engine=E>>(

--- a/src/ext/map.rs
+++ b/src/ext/map.rs
@@ -23,6 +23,7 @@ macro_rules! impl_tuple_map {
         {
             type Output = Out;
             fn dirty(&mut self, _edge:  &<E::AnchorHandle as crate::AnchorHandle>::Token) {
+                println!("map dirtied");
                 self.output_stale = true;
             }
             fn poll_updated<G: UpdateContext<Engine=E>>(

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -120,6 +120,7 @@ impl<T: Eq + Copy + Debug + Key + Ord> MetadataGraph<T> {
         self.nodes.remove(node_id);
     }
 
+    #[allow(dead_code)]
     pub fn necessary_parents<'a>(
         &'a self,
         node_id: T,
@@ -135,6 +136,7 @@ impl<T: Eq + Copy + Debug + Key + Ord> MetadataGraph<T> {
         )
     }
 
+    #[allow(dead_code)]
     pub fn clean_parents<'a>(
         &'a self,
         node_id: T,
@@ -174,7 +176,7 @@ impl<T: Eq + Copy + Debug + Key + Ord> MetadataGraph<T> {
             None => return false,
         };
 
-        node.parents.iter().any(|(v, necessary)| *necessary)
+        node.parents.iter().any(|(_v, necessary)| *necessary)
     }
 
     pub fn height(&self, node_id: T) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,43 +222,85 @@ mod test {
 
         let mut engine = crate::singlethread::Engine::new();
         let (v1, _v1_setter) = crate::var::Var::new(1usize);
-        let a = v1.map(|num1| {
-            *num1 + 1
-        });
-        let b = a.map(|num1| {
-            *num1 + 2
-        });
-        let c = b.map(|num1| {
-            *num1 + 3
-        });
+        let a = v1.map(|num1| *num1 + 1);
+        let b = a.map(|num1| *num1 + 2);
+        let c = b.map(|num1| *num1 + 3);
         engine.mark_observed(&a);
         engine.mark_observed(&c);
 
-        assert_eq!(ObservedState::Unnecessary, engine.check_observed(v1.data.token()));
-        assert_eq!(ObservedState::Observed, engine.check_observed(a.data.token()));
-        assert_eq!(ObservedState::Unnecessary, engine.check_observed(b.data.token()));
-        assert_eq!(ObservedState::Observed, engine.check_observed(c.data.token()));
+        assert_eq!(
+            ObservedState::Unnecessary,
+            engine.check_observed(v1.data.token())
+        );
+        assert_eq!(
+            ObservedState::Observed,
+            engine.check_observed(a.data.token())
+        );
+        assert_eq!(
+            ObservedState::Unnecessary,
+            engine.check_observed(b.data.token())
+        );
+        assert_eq!(
+            ObservedState::Observed,
+            engine.check_observed(c.data.token())
+        );
 
         engine.stabilize();
 
-        assert_eq!(ObservedState::Necessary, engine.check_observed(v1.data.token()));
-        assert_eq!(ObservedState::Observed, engine.check_observed(a.data.token()));
-        assert_eq!(ObservedState::Necessary, engine.check_observed(b.data.token()));
-        assert_eq!(ObservedState::Observed, engine.check_observed(c.data.token()));
+        assert_eq!(
+            ObservedState::Necessary,
+            engine.check_observed(v1.data.token())
+        );
+        assert_eq!(
+            ObservedState::Observed,
+            engine.check_observed(a.data.token())
+        );
+        assert_eq!(
+            ObservedState::Necessary,
+            engine.check_observed(b.data.token())
+        );
+        assert_eq!(
+            ObservedState::Observed,
+            engine.check_observed(c.data.token())
+        );
 
         engine.mark_unobserved(&c);
 
-        assert_eq!(ObservedState::Necessary, engine.check_observed(v1.data.token()));
-        assert_eq!(ObservedState::Observed, engine.check_observed(a.data.token()));
-        assert_eq!(ObservedState::Unnecessary, engine.check_observed(b.data.token()));
-        assert_eq!(ObservedState::Unnecessary, engine.check_observed(c.data.token()));
+        assert_eq!(
+            ObservedState::Necessary,
+            engine.check_observed(v1.data.token())
+        );
+        assert_eq!(
+            ObservedState::Observed,
+            engine.check_observed(a.data.token())
+        );
+        assert_eq!(
+            ObservedState::Unnecessary,
+            engine.check_observed(b.data.token())
+        );
+        assert_eq!(
+            ObservedState::Unnecessary,
+            engine.check_observed(c.data.token())
+        );
 
         engine.mark_unobserved(&a);
 
-        assert_eq!(ObservedState::Unnecessary, engine.check_observed(v1.data.token()));
-        assert_eq!(ObservedState::Unnecessary, engine.check_observed(a.data.token()));
-        assert_eq!(ObservedState::Unnecessary, engine.check_observed(b.data.token()));
-        assert_eq!(ObservedState::Unnecessary, engine.check_observed(c.data.token()));
+        assert_eq!(
+            ObservedState::Unnecessary,
+            engine.check_observed(v1.data.token())
+        );
+        assert_eq!(
+            ObservedState::Unnecessary,
+            engine.check_observed(a.data.token())
+        );
+        assert_eq!(
+            ObservedState::Unnecessary,
+            engine.check_observed(b.data.token())
+        );
+        assert_eq!(
+            ObservedState::Unnecessary,
+            engine.check_observed(c.data.token())
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,21 +231,29 @@ mod test {
         let c = b.map(|num1| {
             *num1 + 3
         });
+        engine.mark_observed(&a);
         engine.mark_observed(&c);
 
         assert_eq!(ObservedState::Unnecessary, engine.check_observed(v1.data.token()));
-        assert_eq!(ObservedState::Unnecessary, engine.check_observed(a.data.token()));
+        assert_eq!(ObservedState::Observed, engine.check_observed(a.data.token()));
         assert_eq!(ObservedState::Unnecessary, engine.check_observed(b.data.token()));
         assert_eq!(ObservedState::Observed, engine.check_observed(c.data.token()));
 
         engine.stabilize();
 
         assert_eq!(ObservedState::Necessary, engine.check_observed(v1.data.token()));
-        assert_eq!(ObservedState::Necessary, engine.check_observed(a.data.token()));
+        assert_eq!(ObservedState::Observed, engine.check_observed(a.data.token()));
         assert_eq!(ObservedState::Necessary, engine.check_observed(b.data.token()));
         assert_eq!(ObservedState::Observed, engine.check_observed(c.data.token()));
 
         engine.mark_unobserved(&c);
+
+        assert_eq!(ObservedState::Necessary, engine.check_observed(v1.data.token()));
+        assert_eq!(ObservedState::Observed, engine.check_observed(a.data.token()));
+        assert_eq!(ObservedState::Unnecessary, engine.check_observed(b.data.token()));
+        assert_eq!(ObservedState::Unnecessary, engine.check_observed(c.data.token()));
+
+        engine.mark_unobserved(&a);
 
         assert_eq!(ObservedState::Unnecessary, engine.check_observed(v1.data.token()));
         assert_eq!(ObservedState::Unnecessary, engine.check_observed(a.data.token()));

--- a/src/singlethread.rs
+++ b/src/singlethread.rs
@@ -116,7 +116,9 @@ impl Engine {
             for child in &necessary_children {
                 // TODO this may need to be dirty in some cases?? may want to better track if a value has been
                 // changed or not
-                let res = self.graph.set_edge(*child, next_id, graph::EdgeState::Clean);
+                let res = self
+                    .graph
+                    .set_edge(*child, next_id, graph::EdgeState::Clean);
                 self.panic_if_loop(res);
             }
             queue.append(&mut necessary_children);
@@ -205,13 +207,7 @@ impl Engine {
     }
 
     pub fn check_observed(&self, id: NodeNum) -> ObservedState {
-        if self
-                .nodes
-                .borrow()
-                .get(id)
-                .as_ref()
-                .unwrap()
-                .observed {
+        if self.nodes.borrow().get(id).as_ref().unwrap().observed {
             return ObservedState::Observed;
         }
         if self.graph.is_necessary(id) {
@@ -454,7 +450,8 @@ impl<'eng> UpdateContext for EngineContextMut<'eng> {
     ) -> Poll {
         let height_increases =
             self.engine.graph.height(anchor.data.num) < self.engine.graph.height(self.node_num);
-        let self_is_necessary = self.engine.check_observed(self.node_num) != ObservedState::Unnecessary;
+        let self_is_necessary =
+            self.engine.check_observed(self.node_num) != ObservedState::Unnecessary;
         if !height_increases {
             let res = self
                 .engine

--- a/src/singlethread.rs
+++ b/src/singlethread.rs
@@ -405,8 +405,6 @@ impl<'eng> UpdateContext for EngineContextMut<'eng> {
             self.pending_on_anchor_get = true;
             Poll::Pending
         } else {
-            let edge =
-                self.engine.graph.edge(anchor.data.num, self.node_num) == graph::EdgeState::Dirty;
             match self.engine.graph.edge(anchor.data.num, self.node_num) {
                 graph::EdgeState::Dirty => {
                     let res = self.engine.graph.set_edge(

--- a/src/singlethread.rs
+++ b/src/singlethread.rs
@@ -166,11 +166,17 @@ impl Engine {
                 "   --   "
             };
             let state = match self.to_recalculate.state(node_id) {
-                NodeState::NeedsRecalc =>   "NeedsRecalc  ",
+                NodeState::NeedsRecalc => "NeedsRecalc  ",
                 NodeState::PendingRecalc => "PendingRecalc",
-                NodeState::Ready =>         "Ready        ",
+                NodeState::Ready => "Ready        ",
             };
-            debug += &format!("{:>80}  {}  {}  {}\n", node.debug_info.to_string(), necessary, observed, state);
+            debug += &format!(
+                "{:>80}  {}  {}  {}\n",
+                node.debug_info.to_string(),
+                necessary,
+                observed,
+                state
+            );
         }
         debug
     }
@@ -430,9 +436,10 @@ impl<'eng> UpdateContext for EngineContextMut<'eng> {
             self.engine.mark_node_for_recalculation(anchor.data.num);
             if necessary && self_is_necessary {
                 let res = self.engine.graph.set_edge(
-                                        anchor.data.num,
-                                        self.node_num,
-                                        graph::EdgeState::Necessary);
+                    anchor.data.num,
+                    self.node_num,
+                    graph::EdgeState::Necessary,
+                );
                 self.engine.panic_if_loop(res);
             }
             Poll::Pending
@@ -453,7 +460,7 @@ impl<'eng> UpdateContext for EngineContextMut<'eng> {
                     );
                     self.engine.panic_if_loop(res);
                     Poll::Updated
-                },
+                }
                 graph::EdgeState::Necessary => Poll::Updated,
                 graph::EdgeState::Clean => Poll::Unchanged,
             }

--- a/src/singlethread.rs
+++ b/src/singlethread.rs
@@ -428,6 +428,13 @@ impl<'eng> UpdateContext for EngineContextMut<'eng> {
         if self.engine.to_recalculate.state(anchor.data.num) != NodeState::Ready {
             self.pending_on_anchor_get = true;
             self.engine.mark_node_for_recalculation(anchor.data.num);
+            if necessary && self_is_necessary {
+                let res = self.engine.graph.set_edge(
+                                        anchor.data.num,
+                                        self.node_num,
+                                        graph::EdgeState::Necessary);
+                self.engine.panic_if_loop(res);
+            }
             Poll::Pending
         } else if !height_increases {
             self.pending_on_anchor_get = true;

--- a/src/singlethread.rs
+++ b/src/singlethread.rs
@@ -108,7 +108,7 @@ impl Engine {
         let mut queue = vec![anchor.data.num];
 
         while let Some(next_id) = queue.pop() {
-            if self.graph.is_necessary(next_id) {
+            if self.check_observed(next_id) != ObservedState::Unnecessary {
                 // we have another parent still observed, so skip this
                 continue;
             }


### PR DESCRIPTION
- Observed nodes now are correctly propagated up the graph
- New `debug_state` method on `Engine` helps debug graph state
- `mark_unobserved` now actually recursively unmarks parents that were necessary