### PR TITLE
Speed upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 Cargo.lock
 *.svg
+perf.data
+perf.data.old

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ criterion = "0.3"
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[profile.release]
+debug = true

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -37,42 +37,6 @@ fn stabilize_linear_nodes_simple(c: &mut Criterion) {
     }
 }
 
-fn stabilize_linear_nodes_smallheight(c: &mut Criterion) {
-    for node_count in &[10, 100] {
-        for observed in &[true, false] {
-            c.bench_with_input(
-                BenchmarkId::new(
-                    "stabilize_linear_nodes_smallheight",
-                    format!(
-                        "{}/{}",
-                        node_count,
-                        if *observed { "observed" } else { "unobserved" }
-                    ),
-                ),
-                &(*node_count, *observed),
-                |b, (node_count, observed)| {
-                    let mut engine = Engine::new_with_max_height(128);
-                    let (first_num, set_first_num) = Var::new(0u64);
-                    let mut node = first_num;
-                    for _ in 0..*node_count {
-                        node = node.map(|val| val + black_box(1));
-                    }
-                    if *observed {
-                        engine.mark_observed(&node);
-                    }
-                    assert_eq!(engine.get(&node), *node_count);
-                    let mut update_number = 0;
-                    b.iter(|| {
-                        update_number += 1;
-                        set_first_num.set(update_number);
-                        assert_eq!(engine.get(&node), update_number + *node_count);
-                    });
-                },
-            );
-        }
-    }
-}
-
 fn stabilize_linear_nodes_cutoff(c: &mut Criterion) {
     for node_count in &[10, 100, 1000] {
         for observed in &[true, false] {
@@ -124,6 +88,6 @@ fn stabilize_linear_nodes_cutoff(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default();
-    targets = stabilize_linear_nodes_cutoff, stabilize_linear_nodes_smallheight, stabilize_linear_nodes_simple
+    targets = stabilize_linear_nodes_cutoff, stabilize_linear_nodes_simple
 }
 criterion_main!(benches);

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,12 +1,12 @@
 use anchors::{singlethread::Engine, AnchorExt, Var};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
-fn stabilize_linear_nodes(c: &mut Criterion) {
+fn stabilize_linear_nodes_simple(c: &mut Criterion) {
     for node_count in &[10, 100, 1000] {
         for observed in &[true, false] {
             c.bench_with_input(
                 BenchmarkId::new(
-                    "stabilize_linear_nodes",
+                    "stabilize_linear_nodes_simple",
                     format!(
                         "{}/{}",
                         node_count,
@@ -124,6 +124,6 @@ fn stabilize_linear_nodes_cutoff(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default();
-    targets = stabilize_linear_nodes_cutoff, stabilize_linear_nodes_smallheight, stabilize_linear_nodes
+    targets = stabilize_linear_nodes_cutoff, stabilize_linear_nodes_smallheight, stabilize_linear_nodes_simple
 }
 criterion_main!(benches);

--- a/examples/stabilize_100.rs
+++ b/examples/stabilize_100.rs
@@ -1,7 +1,7 @@
 use anchors::{singlethread::Engine, AnchorExt, Var, VarSetter, Anchor};
 
 const NODE_COUNT: u64 = 100;
-const ITER_COUNT: u64 = 100000;
+const ITER_COUNT: u64 = 1000000;
 const OBSERVED: bool = false;
 
 fn main() {
@@ -21,7 +21,10 @@ fn main() {
 #[inline(never)]
 fn iter(node: Anchor<u64, Engine>, mut engine: Engine, set_first_num: VarSetter<u64, <Engine as anchors::Engine>::DirtyHandle>) {
     let mut update_number = 0;
-    for _ in 0..ITER_COUNT {
+    for i in 0..ITER_COUNT {
+        if i % (ITER_COUNT/100) == 0 {
+            println!("{}%", (i*100)/(ITER_COUNT));
+        }
         update_number += 1;
         set_first_num.set(update_number);
         assert_eq!(engine.get(&node), update_number + NODE_COUNT);

--- a/examples/stabilize_100.rs
+++ b/examples/stabilize_100.rs
@@ -1,0 +1,29 @@
+use anchors::{singlethread::Engine, AnchorExt, Var, VarSetter, Anchor};
+
+const NODE_COUNT: u64 = 100;
+const ITER_COUNT: u64 = 100000;
+const OBSERVED: bool = false;
+
+fn main() {
+    let mut engine = Engine::new_with_max_height(128);
+    let (first_num, set_first_num) = Var::new(0u64);
+    let mut node = first_num;
+    for _ in 0..NODE_COUNT {
+        node = node.map(|val| val + 1);
+    }
+    if OBSERVED {
+        engine.mark_observed(&node);
+    }
+    assert_eq!(engine.get(&node), NODE_COUNT);
+    iter(node, engine, set_first_num);
+}
+
+#[inline(never)]
+fn iter(node: Anchor<u64, Engine>, mut engine: Engine, set_first_num: VarSetter<u64, <Engine as anchors::Engine>::DirtyHandle>) {
+    let mut update_number = 0;
+    for _ in 0..ITER_COUNT {
+        update_number += 1;
+        set_first_num.set(update_number);
+        assert_eq!(engine.get(&node), update_number + NODE_COUNT);
+    }
+}

--- a/src/fakeheap.rs
+++ b/src/fakeheap.rs
@@ -1,5 +1,6 @@
 pub struct FakeHeap<T> {
-    min_height: usize,
+    current_min_height: usize,
+    current_max_height: usize,
     lists: Vec<Vec<T>>,
 }
 
@@ -11,7 +12,8 @@ impl<T> FakeHeap<T> {
         }
         Self {
             lists,
-            min_height: max_height,
+            current_min_height: max_height,
+            current_max_height: 0,
         }
     }
 
@@ -24,17 +26,19 @@ impl<T> FakeHeap<T> {
             );
         }
         self.lists[height].push(item);
-        self.min_height = self.min_height.min(height);
+        self.current_min_height = self.current_min_height.min(height);
+        self.current_max_height = self.current_max_height.max(height);
     }
 
     pub fn pop_min(&mut self) -> Option<(usize, T)> {
-        while self.min_height < self.lists.len() {
-            if let Some(v) = self.lists[self.min_height].pop() {
-                return Some((self.min_height, v));
+        while self.current_min_height <= self.current_max_height {
+            if let Some(v) = self.lists[self.current_min_height].pop() {
+                return Some((self.current_min_height, v));
             } else {
-                self.min_height += 1;
+                self.current_min_height += 1;
             }
         }
+        self.current_max_height = 0;
         None
     }
 }


### PR DESCRIPTION
- the empty dirty queue now persists, no we don't have to reallocate every time we mark outputs as dirty, resulting in 13-40% speedup on various benchmarks
- current max height in the fake heap is tracked, significantly speeding up (over ~50%) very small updates when max_height is large, since we don't iterate through the entire list of empty height queues. could probably in the future do some fancy skip list stuff for workloads that have a lot of gaps
- we now have two set edge fns for a small perf gain, since fns that set edges as dirty no longer need to validate that no loops were created