### PR TITLE
Dict and MapMut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ bench = false
 
 [dependencies]
 typed-arena = { version = "2.0.1" }
+im = { version = "15.0.0" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -2,7 +2,7 @@ use crate::{Anchor, Engine};
 use im::OrdMap;
 use im::ordmap::DiffItem;
 
-type Dict<K, V> = OrdMap<K, V>;
+pub type Dict<K, V> = OrdMap<K, V>;
 
 impl <E: Engine, K, V> Anchor<Dict<K, V>, E> {
     fn filter<F: Fn(K, V) -> bool>(&self, f: F) -> Anchor<Dict<K, V>, E> {

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -20,8 +20,4 @@ impl <E: Engine, K, V> Anchor<Dict<K, V>, E> {
     fn unordered_fold<T, F: for<'a> Fn(&mut T, DiffItem<'a, K, V>)>(&self, initial_state: T, f: F) -> Anchor<T, E> {
         unimplemented!()
     }
-
-    fn merge<F: Fn()>(&self, other: Anchor<Dict<K, V>, E>) -> Anchor<Dict<K, V>, E> {
-        unimplemented!()
-    }
 }

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -1,0 +1,27 @@
+use crate::{Anchor, Engine};
+use im::OrdMap;
+use im::ordmap::DiffItem;
+
+type Dict<K, V> = OrdMap<K, V>;
+
+impl <E: Engine, K, V> Anchor<Dict<K, V>, E> {
+    fn filter<F: Fn(K, V) -> bool>(&self, f: F) -> Anchor<Dict<K, V>, E> {
+        unimplemented!()
+    }
+
+    fn map<F: Fn(K, V) -> T, T>(&self, f: F) -> Anchor<Dict<K, T>, E> {
+        unimplemented!()
+    }
+
+    fn filter_map<F: Fn(K, V) -> Option<T>, T>(&self, f: F) -> Anchor<Dict<K, T>, E> {
+        unimplemented!()
+    }
+
+    fn unordered_fold<T, F: for<'a> Fn(&mut T, DiffItem<'a, K, V>)>(&self, initial_state: T, f: F) -> Anchor<T, E> {
+        unimplemented!()
+    }
+
+    fn merge<F: Fn()>(&self, other: Anchor<Dict<K, V>, E>) -> Anchor<Dict<K, V>, E> {
+        unimplemented!()
+    }
+}

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -1,23 +1,128 @@
-use crate::{Anchor, Engine};
+use crate::{Anchor, Engine, AnchorExt};
 use im::OrdMap;
 use im::ordmap::DiffItem;
 
 pub type Dict<K, V> = OrdMap<K, V>;
 
-impl <E: Engine, K, V> Anchor<Dict<K, V>, E> {
-    fn filter<F: Fn(K, V) -> bool>(&self, f: F) -> Anchor<Dict<K, V>, E> {
-        unimplemented!()
+impl <E: Engine, K: Ord + Clone + PartialEq + 'static, V: Clone + PartialEq + 'static> Anchor<Dict<K, V>, E> {
+    pub fn filter<F: FnMut(&K, &V) -> bool + 'static>(&self, mut f: F) -> Anchor<Dict<K, V>, E> {
+        self.filter_map(move |k, v| if f(k, v) {
+            Some(v.clone())
+        } else {
+            None
+        })
     }
 
-    fn map<F: Fn(K, V) -> T, T>(&self, f: F) -> Anchor<Dict<K, T>, E> {
-        unimplemented!()
+    pub fn map<F: FnMut(&K, &V) -> T + 'static, T: Clone + PartialEq + 'static>(&self, mut f: F) -> Anchor<Dict<K, T>, E> {
+        self.filter_map(move |k, v| Some(f(k, v)))
     }
 
-    fn filter_map<F: Fn(K, V) -> Option<T>, T>(&self, f: F) -> Anchor<Dict<K, T>, E> {
-        unimplemented!()
+    pub fn filter_map<F: FnMut(&K, &V) -> Option<T> + 'static, T: Clone + PartialEq + 'static>(&self, mut f: F) -> Anchor<Dict<K, T>, E> {
+        self.unordered_fold(Dict::new(), move |out, diff_item| {
+            match diff_item {
+                DiffItem::Add(k, v) => {
+                    if let Some(new) = f(k, v) {
+                        out.insert(k.clone(), new);
+                        return true;
+                    }
+                }
+                DiffItem::Update{new: (k, v), old: _} => {
+                    if let Some(new) = f(k, v) {
+                        out.insert(k.clone(), new);
+                        return true;
+                    } else if out.contains_key(k) {
+                        out.remove(k);
+                        return true;
+                    }
+                }
+                DiffItem::Remove(k, v) => {
+                    out.remove(k);
+                    return true;
+                }
+            }
+            false
+        })
     }
 
-    fn unordered_fold<T, F: for<'a> Fn(&mut T, DiffItem<'a, K, V>)>(&self, initial_state: T, f: F) -> Anchor<T, E> {
-        unimplemented!()
+    pub fn unordered_fold<T: PartialEq + Clone + 'static, F: for<'a> FnMut(&mut T, DiffItem<'a, K, V>) -> bool + 'static>(&self, initial_state: T, mut f: F) -> Anchor<T, E> {
+        let mut last_observation = Dict::new();
+        self.map_mut(initial_state, move |mut out, this| {
+            let mut did_update = false;
+            for item in last_observation.diff(this) {
+                if f(&mut out, item) {
+                    did_update = true;
+                }
+            }
+            last_observation = this.clone();
+            did_update
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_filter() {
+        let mut engine = crate::singlethread::Engine::new();
+        let mut dict = Dict::new();
+        let (a, a_setter) = crate::var::Var::new(dict.clone());
+        let b = a.filter(|_, n| *n > 10);
+        let b_out = engine.get(&b);
+        assert_eq!(0, b_out.len());
+
+        dict.insert("a".to_string(), 1);
+        dict.insert("b".to_string(), 23);
+        dict.insert("c".to_string(), 5);
+        dict.insert("d".to_string(), 24);
+        a_setter.set(dict.clone());
+        let b_out = engine.get(&b);
+        assert_eq!(2, b_out.len());
+        assert_eq!(Some(&23), b_out.get("b"));
+        assert_eq!(Some(&24), b_out.get("d"));
+
+        dict.insert("a".to_string(), 25);
+        dict.insert("b".to_string(), 5);
+        dict.remove("d");
+        dict.insert("e".to_string(), 50);
+        a_setter.set(dict.clone());
+        let b_out = engine.get(&b);
+        assert_eq!(2, b_out.len());
+        assert_eq!(Some(&25), b_out.get("a"));
+        assert_eq!(Some(&50), b_out.get("e"));
+    }
+
+    #[test]
+    fn test_map() {
+        let mut engine = crate::singlethread::Engine::new();
+        let mut dict = Dict::new();
+        let (a, a_setter) = crate::var::Var::new(dict.clone());
+        let b = a.map(|_, n| *n + 1);
+        let b_out = engine.get(&b);
+        assert_eq!(0, b_out.len());
+
+        dict.insert("a".to_string(), 1);
+        dict.insert("b".to_string(), 2);
+        dict.insert("c".to_string(), 3);
+        dict.insert("d".to_string(), 4);
+        a_setter.set(dict.clone());
+        let b_out = engine.get(&b);
+        assert_eq!(4, b_out.len());
+        assert_eq!(Some(&2), b_out.get("a"));
+        assert_eq!(Some(&3), b_out.get("b"));
+        assert_eq!(Some(&4), b_out.get("c"));
+        assert_eq!(Some(&5), b_out.get("d"));
+
+        dict.insert("a".to_string(), 10);
+        dict.insert("b".to_string(), 11);
+        dict.remove("d");
+        dict.insert("e".to_string(), 12);
+        a_setter.set(dict.clone());
+        let b_out = engine.get(&b);
+        assert_eq!(4, b_out.len());
+        assert_eq!(Some(&11), b_out.get("a"));
+        assert_eq!(Some(&12), b_out.get("b"));
+        assert_eq!(Some(&4), b_out.get("c"));
+        assert_eq!(Some(&13), b_out.get("e"));
     }
 }

--- a/src/ext/map_mut.rs
+++ b/src/ext/map_mut.rs
@@ -1,0 +1,154 @@
+use crate::{Anchor, AnchorInner, Engine, OutputContext, Poll, UpdateContext};
+use std::panic::Location;
+
+pub struct MapMut<A, F, Out> {
+    pub(super) f: F,
+    pub(super) output: Out,
+    pub(super) output_stale: bool,
+    pub(super) anchors: A,
+    pub(super) location: &'static Location<'static>,
+}
+
+macro_rules! impl_tuple_map_mut {
+    ($([$output_type:ident, $num:tt])+) => {
+        impl<$($output_type,)+ E, F, Out> AnchorInner<E> for
+            MapMut<($(Anchor<$output_type, E>,)+), F, Out>
+        where
+            F: for<'any> FnMut(&'any mut Out, $(&'any $output_type),+) -> bool,
+            Out: PartialEq + 'static,
+            $(
+                $output_type: 'static,
+            )+
+            E: Engine,
+        {
+            type Output = Out;
+            fn dirty(&mut self, _edge:  &<E::AnchorHandle as crate::AnchorHandle>::Token) {
+                self.output_stale = true;
+            }
+            fn poll_updated<G: UpdateContext<Engine=E>>(
+                &mut self,
+                ctx: &mut G,
+            ) -> Poll {
+                if !self.output_stale {
+                    return Poll::Unchanged;
+                }
+
+                let mut found_pending = false;
+                let mut found_updated = false;
+
+                $(
+                    match ctx.request(&self.anchors.$num, true) {
+                        Poll::Pending => {
+                            found_pending = true;
+                        }
+                        Poll::Updated => {
+                            found_updated = true;
+                        }
+                        Poll::Unchanged => {
+                            // do nothing
+                        }
+                    }
+                )+
+
+                if found_pending {
+                    return Poll::Pending;
+                }
+
+                self.output_stale = false;
+
+                if found_updated {
+                    let did_update = (self.f)(&mut self.output, $(&ctx.get(&self.anchors.$num)),+);
+                    if did_update {
+                        return Poll::Updated
+                    }
+                }
+                Poll::Unchanged
+            }
+            fn output<'slf, 'out, G: OutputContext<'out, Engine=E>>(
+                &'slf self,
+                _ctx: &mut G,
+            ) -> &'out Self::Output
+            where
+                'slf: 'out,
+            {
+                &self.output
+            }
+
+            fn debug_location(&self) -> Option<(&'static str, &'static Location<'static>)> {
+                Some(("map", self.location))
+            }
+        }
+    }
+}
+
+impl_tuple_map_mut! {
+    [O0, 0]
+}
+
+impl_tuple_map_mut! {
+    [O0, 0]
+    [O1, 1]
+}
+
+impl_tuple_map_mut! {
+    [O0, 0]
+    [O1, 1]
+    [O2, 2]
+}
+
+impl_tuple_map_mut! {
+    [O0, 0]
+    [O1, 1]
+    [O2, 2]
+    [O3, 3]
+}
+
+impl_tuple_map_mut! {
+    [O0, 0]
+    [O1, 1]
+    [O2, 2]
+    [O3, 3]
+    [O4, 4]
+}
+
+impl_tuple_map_mut! {
+    [O0, 0]
+    [O1, 1]
+    [O2, 2]
+    [O3, 3]
+    [O4, 4]
+    [O5, 5]
+}
+
+impl_tuple_map_mut! {
+    [O0, 0]
+    [O1, 1]
+    [O2, 2]
+    [O3, 3]
+    [O4, 4]
+    [O5, 5]
+    [O6, 6]
+}
+
+impl_tuple_map_mut! {
+    [O0, 0]
+    [O1, 1]
+    [O2, 2]
+    [O3, 3]
+    [O4, 4]
+    [O5, 5]
+    [O6, 6]
+    [O7, 7]
+}
+
+impl_tuple_map_mut! {
+    [O0, 0]
+    [O1, 1]
+    [O2, 2]
+    [O3, 3]
+    [O4, 4]
+    [O5, 5]
+    [O6, 6]
+    [O7, 7]
+    [O8, 8]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod singlethread;
 mod var;
 pub use constant::Constant;
 pub use var::{Var, VarSetter};
+mod dict;
 
 /// Indicates whether a value is ready for reading, and if it is, whether it's changed
 /// since the last read.


### PR DESCRIPTION
This adds an incremental map based on `im::ordmap`, and a new core Anchor called MapMut, a map that mutates its output in response to new inputs instead of generating new outputs.

Calling the incremental map `Dict` to avoid the problem `IncrMap` has where there are two very different definitions of 'map' in close proximity. May change to something else later.