### PR TITLE
impl vector for anchor

### DIFF
--- a/src/collections.rs
+++ b/src/collections.rs
@@ -1,4 +1,4 @@
-mod ord_map;
+pub mod ord_map;
 mod ord_set;
 mod rope;
 mod vector;

--- a/src/collections/ord_map.rs
+++ b/src/collections/ord_map.rs
@@ -7,11 +7,15 @@ pub type Dict<K, V> = OrdMap<K, V>;
 impl<E: Engine, K: Ord + Clone + PartialEq + 'static, V: Clone + PartialEq + 'static>
     Anchor<Dict<K, V>, E>
 {
+    #[track_caller]
     pub fn filter<F: FnMut(&K, &V) -> bool + 'static>(&self, mut f: F) -> Anchor<Dict<K, V>, E> {
         self.filter_map(move |k, v| if f(k, v) { Some(v.clone()) } else { None })
     }
 
     // TODO rlord: fix this name god
+
+    #[track_caller]
+
     pub fn map_<F: FnMut(&K, &V) -> T + 'static, T: Clone + PartialEq + 'static>(
         &self,
         mut f: F,
@@ -20,6 +24,7 @@ impl<E: Engine, K: Ord + Clone + PartialEq + 'static, V: Clone + PartialEq + 'st
     }
 
     /// FOOBAR
+    #[track_caller]
     pub fn filter_map<F: FnMut(&K, &V) -> Option<T> + 'static, T: Clone + PartialEq + 'static>(
         &self,
         mut f: F,
@@ -52,7 +57,7 @@ impl<E: Engine, K: Ord + Clone + PartialEq + 'static, V: Clone + PartialEq + 'st
             false
         })
     }
-
+    #[track_caller]
     pub fn unordered_fold<
         T: PartialEq + Clone + 'static,
         F: for<'a> FnMut(&mut T, DiffItem<'a, K, V>) -> bool + 'static,

--- a/src/collections/vector.rs
+++ b/src/collections/vector.rs
@@ -1,1 +1,112 @@
-// TODO
+use im::Vector;
+
+use crate::expert::{
+    Anchor, AnchorHandle, AnchorInner, Engine, OutputContext, Poll, UpdateContext,
+};
+use std::panic::Location;
+
+impl<I: 'static + Clone, E: Engine> std::iter::FromIterator<Anchor<I, E>> for Anchor<Vector<I>, E> {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = Anchor<I, E>>,
+    {
+        VectorCollect::new(iter.into_iter().collect())
+    }
+}
+
+impl<'a, I: 'static + Clone, E: Engine> std::iter::FromIterator<&'a Anchor<I, E>>
+    for Anchor<Vector<I>, E>
+{
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = &'a Anchor<I, E>>,
+    {
+        VectorCollect::new(iter.into_iter().cloned().collect())
+    }
+}
+
+struct VectorCollect<T, E: Engine> {
+    anchors: Vector<Anchor<T, E>>,
+    vals: Option<Vector<T>>,
+    location: &'static Location<'static>,
+}
+
+impl<T: 'static + Clone, E: Engine> VectorCollect<T, E> {
+    #[track_caller]
+    pub fn new(anchors: Vector<Anchor<T, E>>) -> Anchor<Vector<T>, E> {
+        E::mount(Self {
+            anchors,
+            vals: None,
+            location: Location::caller(),
+        })
+    }
+}
+
+impl<T: 'static + Clone, E: Engine> AnchorInner<E> for VectorCollect<T, E> {
+    type Output = Vector<T>;
+    fn dirty(&mut self, _edge: &<E::AnchorHandle as AnchorHandle>::Token) {
+        self.vals = None;
+    }
+
+    fn poll_updated<G: UpdateContext<Engine = E>>(&mut self, ctx: &mut G) -> Poll {
+        if self.vals.is_none() {
+            let pending_exists = self
+                .anchors
+                .iter()
+                .any(|anchor| ctx.request(anchor, true) == Poll::Pending);
+            if pending_exists {
+                return Poll::Pending;
+            }
+            self.vals = Some(
+                self.anchors
+                    .iter()
+                    .map(|anchor| ctx.get(anchor).clone())
+                    .collect(),
+            )
+        }
+        Poll::Updated
+    }
+
+    fn output<'slf, 'out, G: OutputContext<'out, Engine = E>>(
+        &'slf self,
+        _ctx: &mut G,
+    ) -> &'out Self::Output
+    where
+        'slf: 'out,
+    {
+        &self.vals.as_ref().unwrap()
+    }
+
+    fn debug_location(&self) -> Option<(&'static str, &'static Location<'static>)> {
+        Some(("VectorCollect", self.location))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::singlethread::*;
+    use im::vector;
+    use im::Vector;
+
+    #[test]
+    fn collect() {
+        let mut engine = Engine::new();
+        let a = Var::new(1);
+        let b = Var::new(2);
+        let c = Var::new(5);
+        let nums: Anchor<Vector<_>> = vector![a.watch(), b.watch(), c.watch()]
+            .into_iter()
+            .collect();
+        let sum: Anchor<usize> = nums.map(|nums| nums.iter().sum());
+        let ns: Anchor<usize> = nums.map(|nums: &Vector<_>| nums.len());
+
+        assert_eq!(engine.get(&sum), 8);
+
+        a.set(2);
+        assert_eq!(engine.get(&sum), 9);
+
+        c.set(1);
+        assert_eq!(engine.get(&sum), 5);
+        println!("ns {}", engine.get(&ns));
+    }
+}

--- a/src/expert.rs
+++ b/src/expert.rs
@@ -176,6 +176,11 @@ pub trait AnchorInner<E: Engine + ?Sized> {
 }
 
 mod ext;
+pub use ext::cutoff;
+pub use ext::map;
+pub use ext::map_mut;
+pub use ext::refmap;
+pub use ext::then;
 pub use ext::MultiAnchor;
 pub(crate) mod constant;
 mod var;

--- a/src/expert/ext.rs
+++ b/src/expert/ext.rs
@@ -1,11 +1,11 @@
 use super::{Anchor, AnchorInner, Engine};
 use std::panic::Location;
 
-mod cutoff;
-mod map;
-mod map_mut;
-mod refmap;
-mod then;
+pub mod cutoff;
+pub mod map;
+pub mod map_mut;
+pub mod refmap;
+pub mod then;
 
 /// A trait automatically implemented for tuples of Anchors.
 ///


### PR DESCRIPTION
I simply made im::vector collections like rust vec implementation in src.

also,  because I need expose/use some like 
`ord_map`, 
`ext::cutoff`
`ext::map`
`ext::map_mut`
`ext::refmap`
`ext::then` 
in my lib, I made a wapper struct for Anchor and Var,  so I edited some file.